### PR TITLE
Added couple of improvements and bug fixes

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -53,6 +53,7 @@ const ANGULAR_COMPONENT = {
   'directive': 'directive',
   'filter': 'filter',
   'constant': 'constant',
+  'value': 'value',
   'service': 'service',
   'factory': 'factory',
   'provider': 'provider',

--- a/src/resolvers/component-resolver.js
+++ b/src/resolvers/component-resolver.js
@@ -213,6 +213,8 @@ class ComponentResolver {
   }
 
   resolveConstant(component, cmpDeclarationToken) {
+    // TODO @saskodh: the constant can be number or concatenated string
+    // TODO @saskodh: add semicolon at the end of the constant definition
     if (this.isObjectLiteral(cmpDeclarationToken)) {
       component.object = true;
       this.resolveComponentInside(component, '{');
@@ -253,7 +255,9 @@ class ComponentResolver {
           if (ctrl.text === KEYWORDS.function) {
             component.internalControllerIndex = ctrl.index;
           }
-        } else if (current.text === 'templateUrl') {
+        } else if (current.text === 'templateUrl' && !component.templateUrl) {
+          // NOTE @saskodh: if templateUrl not yet resolved
+          // Didn't had time to debug it why but in some files where that have templateUrl somewhere in the code, it tries to use it
           component.templateUrlIndex = current.index;
           this.consume(':');
           let templateUrlToken = this.next();
@@ -268,13 +272,13 @@ class ComponentResolver {
         stack.pop();
       }
     }
-    
+
     current = !component.object ? current : this.next();
-    
+
     if (current.text === ')') {
       this.addTokenToRemove(current);
     }
-    
+
     if (this.peek(';')) {
       this.addTokenToRemove(this.consume(';'));
     }
@@ -295,7 +299,8 @@ class ComponentResolver {
   }
 
   isAngularConstant(component) {
-    return ANGULAR_COMPONENT.constant === component.type;
+    // NOTE @saskodh: support for angular.value (same as constant)
+    return ANGULAR_COMPONENT.constant === component.type || ANGULAR_COMPONENT.value === component.type;
   }
 
   /**

--- a/test/module-resolver.spec.js
+++ b/test/module-resolver.spec.js
@@ -7,7 +7,7 @@ describe('ModuleResolver', () => {
   beforeEach(() => {
     moduleResolver = new ModuleResolver();
   });
-  
+
   it('should return text for a given module', () => {
     //given
     let components = {
@@ -30,7 +30,7 @@ describe('ModuleResolver', () => {
     //then
     expect(result['my.module'].path).toBe('src/test');
     expect(result['my.module'].text).toBe(
-      'import {myCtrl} from \'src/test/my-ctrl.js\';\n' +
+      'import {myCtrl} from \'./test/my-ctrl\';\n' +
       '\n' +
       'angular.module(\'my.module\', [\n' +
       '\t\'my.dep1\',\n' +
@@ -65,8 +65,8 @@ describe('ModuleResolver', () => {
     //then
     expect(result['my.module'].path).toBe('src/test');
     expect(result['my.module'].text).toBe(
-      'import {myCtrl} from \'src/test/my-ctrl.js\';\n' +
-      'import {myFactory} from \'src/test/my-factory.js\';\n' +
+      'import {myCtrl} from \'./test/my-ctrl\';\n' +
+      'import {myFactory} from \'./test/my-factory\';\n' +
       '\n' +
       'angular.module(\'my.module\', [\n' +
       '\t\'my.dep1\',\n' +
@@ -102,7 +102,7 @@ describe('ModuleResolver', () => {
     //then
     expect(result['my.module'].path).toBe('src/test');
     expect(result['my.module'].text).toBe(
-      'import {myCtrl} from \'src/test/my-ctrl.js\';\n' +
+      'import {myCtrl} from \'./test/my-ctrl\';\n' +
       '\n' +
       'angular.module(\'my.module\', [\n' +
       '\t\'my.dep1\',\n' +

--- a/test/transformer.spec.js
+++ b/test/transformer.spec.js
@@ -44,10 +44,10 @@ describe('transformer', () => {
       '/*@ngInject*/\n' +
       'function MyController () {}' +
       '\n/*@ngInject*/\n' +
-      'function MyController1 () {}' +
+      'function MyController1Controller () {}' +
       '\n/*@ngInject*/\n' +
-      'function MyController2 () {}' +
-      '\nexport {MyController, MyController1, MyController2};'
+      'function MyController2Controller () {}' +
+      '\nexport {MyController, MyController1Controller, MyController2Controller};'
     );
   });
 
@@ -68,8 +68,8 @@ describe('transformer', () => {
       '\n/*@ngInject*/\n' +
       'function myFilter(){}' +
       '\n/*@ngInject*/\n' +
-      'function MyController2(){}' +
-      '\nexport {myFactory, myFilter, MyController2};'
+      'function MyController2Controller(){}' +
+      '\nexport {myFactory, myFilter, MyController2Controller};'
     );
   });
 
@@ -88,10 +88,10 @@ describe('transformer', () => {
     expect(result).toBe(
       '/*ngInject*/var MyController = function () {};' +
       '\n/*@ngInject*/\n' +
-      'function MyController1 () {}' +
+      'function MyController1Controller () {}' +
       '\n/*@ngInject*/\n' +
-      'function MyController2 () {}' +
-      '\nexport {MyController, MyController1, MyController2};'
+      'function MyController2Controller () {}' +
+      '\nexport {MyController, MyController1Controller, MyController2Controller};'
     );
   });
 
@@ -112,8 +112,8 @@ describe('transformer', () => {
     expect(result).toBe(
       '/*ngInject*/var MyController = function () {};\n' +
       '/*ngInject*/var myService = function () {};\n' +
-      '/*@ngInject*/\nfunction MyController2 () {}\n' +
-      '\nexport {MyController, MyController2, myService};'
+      '/*@ngInject*/\nfunction MyController2Controller () {}\n' +
+      '\nexport {MyController, MyController2Controller, myService};'
     );
   });
 
@@ -158,10 +158,10 @@ describe('transformer', () => {
     //then
     expect(result).toBe(
       '/*@ngInject*/\n' +
-      'function config () {' +
+      'function fileConfig1 () {' +
         'stateProvider.state({template: require(\'./template.url\'),controller: /*ngInject*/function () {}});' +
       '}'+
-      '\nexport {config};'
+      '\nexport {fileConfig1};'
     );
   });
 


### PR DESCRIPTION
## Added couple of improvements and bug fixes
- added support for angular.value (same as constant)
- sort components by type when registering to angular (cleaner index.js)
- fixed bug with run and config functions
  - angular.run and angular.config take only function as parameter
  - generate suitable name for exported run and config functions (fileName + type + index)
- generate correct import path when importing components in index.js
- fixed bug with exported components names (ex. service and directive may have same name)
- fixed bug with templateUrl => ex. sometimes was trying to read templateUrl from the directive's controller code

[partially reviewed by @hdimitrieski]